### PR TITLE
fix: allow empty har field

### DIFF
--- a/packages/plugin/src/install.ts
+++ b/packages/plugin/src/install.ts
@@ -23,14 +23,18 @@ const createDumpFile = (data: TestExecutionResult): string => {
   return resultsPath;
 };
 
-const getHar = (filename: string): HttpArchiveLog => {
-  const filePath = path.join(harDir, filename);
-  const data = readFile(filePath);
-  const parsed = JSON.parse(data.toString('utf-8'));
+const getHar = (filename: string): HttpArchiveLog | null => {
+  try {
+    const filePath = path.join(harDir, filename);
+    const data = readFile(filePath);
+    const parsed = JSON.parse(data.toString('utf-8'));
 
-  removeFile(filePath);
+    removeFile(filePath);
 
-  return parsed;
+    return parsed;
+  } catch (error) {
+    return null;
+  }
 };
 
 function install(on: Cypress.PluginEvents, options?: PluginOptions) {

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -125,7 +125,7 @@ export type TestExecutionResult = {
   meta: RunContextData;
   cy: CypressEvent[];
   rr: RRWebEvent[];
-  har: HttpArchiveLog;
+  har: HttpArchiveLog | null;
   browserLogs: BrowserLog;
   pluginMeta?: Record<string, unknown>;
 };


### PR DESCRIPTION
Set the `har` field to `null` if the HAR file was not generated. Details #36 